### PR TITLE
[Audio] Hotfix to issue #511

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1305,7 +1305,9 @@ class Audio:
             await self.bot.say("I'm already downloading a file!")
             return
 
-        if "." in url:
+        URLMatch = re.compile('@^(https?|ftp)://[^\s/$.?#].[^\s]*$@iS', re.IGNORECASE)
+
+        if URLMatch.match(url):
             if not self._valid_playable_url(url):
                 await self.bot.say("That's not a valid URL.")
                 return


### PR DESCRIPTION
Instead of checking for a URL based on a single dot, it actually uses RegEx, this way it should get most URLs correctly, as you know, it's of RegEx nature to fail alot so more experimentation is needed, but it should work.